### PR TITLE
Drop route-data from IPv4 Settings when irrelevant

### DIFF
--- a/NetworkManager.py
+++ b/NetworkManager.py
@@ -516,6 +516,12 @@ class fixups(object):
                     settings['ipv4']['addresses'] = [fixups.addrconf_to_dbus(addr,socket.AF_INET) for addr in settings['ipv4']['addresses']]
                 if 'routes' in settings['ipv4']:
                     settings['ipv4']['routes'] = [fixups.route_to_dbus(route,socket.AF_INET) for route in settings['ipv4']['routes']]
+                    if len(settings['ipv4']['routes']) > 0:
+                        # When 'routes' is set 'route-data' is ignored. There
+                        # isn't currently a dbus encoding for 'route-data' so
+                        # in these cases where it is not going to be processed
+                        # anyway, let's drop it.
+                        settings['ipv4'].pop('route-data', None)
                 if 'dns' in settings['ipv4']:
                     settings['ipv4']['dns'] = [fixups.addr_to_dbus(addr,socket.AF_INET) for addr in settings['ipv4']['dns']]
             if 'ipv6' in settings:


### PR DESCRIPTION
There isn't currently a dbus encoding for the 'route-data' object so in
the cases where it is specified and 'routes' is not the application will
throw an exception, as it should.

When 'routes' is specified 'route-data' is ignored in IPv4 Settings
by NetworkManager [1]. Let's fix this by just dropping 'route-data' from
the message in these cases.

[1] https://developer.gnome.org/NetworkManager/stable/settings-ipv4.html